### PR TITLE
Fix PIDcontroller.h dependency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library includes code for accessing the LSM6DS33, forked from the separate 
 Add the following lines to your platformio.ini file:
 
 ~~~{.cpp}
-lib_deps = 
+lib_deps =
      Wire
      wpi-32u4-library
 ~~~
@@ -46,7 +46,7 @@ This library also includes copies of several other Arduino libraries inside it w
 
 You can use these libraries in your sketch automatically without any extra installation steps and without needing to add any extra `#include` lines to your sketch.
 
-You should avoid adding extra `#include` lines such as `#include <Pushbutton.h>` because then the Arduino IDE might try to use the standalone Pushbutton library (if you previously installed it), and it would conflict with the copy of the Pushbutton code included in this library. 
+You should avoid adding extra `#include` lines such as `#include <Pushbutton.h>` because then the Arduino IDE might try to use the standalone Pushbutton library (if you previously installed it), and it would conflict with the copy of the Pushbutton code included in this library.
 
 ## Documentation
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=wpi-32u4-library
-version=3.5.2
+version=3.5.3
 author=Pololu,WPIRoboticsEngineering
 maintainer=Greg Lewin
 sentence=Forked Romi 32U4 Arduino library

--- a/src/Chassis.cpp
+++ b/src/Chassis.cpp
@@ -66,6 +66,15 @@ void Chassis::setWheelSpeeds(float leftSpeed, float rightSpeed)
     rightMotor.setTargetSpeed(rightTicksPerInterval);
 }
 
+float Chassis::getLeftWheelSpeed(void)
+{
+    return leftMotor.speed * cmPerEncoderTick * 1000.0 / ctrlIntervalMS;
+}
+
+float Chassis::getRightWheelSpeed(void)
+{
+    return rightMotor.speed * cmPerEncoderTick * 1000.0 / ctrlIntervalMS;
+}
 
 void Chassis::setTwist(float forwardSpeed, float turningSpeed)
 {

--- a/src/Chassis.cpp
+++ b/src/Chassis.cpp
@@ -3,14 +3,14 @@
 /**
  * Call init() in your setup() routine. It sets up some internal timers so that the speed controllers
  * for the wheels will work properly.
- * 
- * Here's how it works: Motor::init() starts a hardware timer on a 16 ms loop. Every time the timer 
- * "rolls over," an interrupt service routine (ISR) is called that updates the motor speeds and 
+ *
+ * Here's how it works: Motor::init() starts a hardware timer on a 16 ms loop. Every time the timer
+ * "rolls over," an interrupt service routine (ISR) is called that updates the motor speeds and
  * sets a flag to notify Chassis that it is time to calculate the control inputs.
- * 
+ *
  * When set up this way, pins 6, 12, and 13 cannot be used with analogWrite()
  * */
-void Chassis::init(void) 
+void Chassis::init(void)
 {
     Romi32U4Motor::init();
 
@@ -27,7 +27,7 @@ void Chassis::init(void)
     OCR4C = 249;   //TOP goes in OCR4C
 
     TIMSK4 = 0x04; //enable overflow interrupt
-    
+
     // re-enable interrupts
     interrupts();
 }
@@ -40,7 +40,7 @@ void Chassis::setMotorPIDcoeffs(float kp, float ki)
 
 
 /**
- * Stops the motors. It calls setMotorEfforts() so that the wheels won't lock. Use setSpeeds() if you want 
+ * Stops the motors. It calls setMotorEfforts() so that the wheels won't lock. Use setSpeeds() if you want
  * the wheels to 'lock' in place.
  * */
 void Chassis::idle(void)
@@ -70,7 +70,7 @@ void Chassis::setWheelSpeeds(float leftSpeed, float rightSpeed)
 void Chassis::setTwist(float forwardSpeed, float turningSpeed)
 {
     int16_t ticksPerIntervalFwd = (forwardSpeed * (ctrlIntervalMS / 1000.0)) / cmPerEncoderTick;
-    int16_t ticksPerIntervalTurn = (robotRadius * 3.14 / 180.0) * 
+    int16_t ticksPerIntervalTurn = (robotRadius * 3.14 / 180.0) *
                         (turningSpeed * (ctrlIntervalMS / 1000.0)) / cmPerEncoderTick;
 
     leftMotor.setTargetSpeed(ticksPerIntervalFwd - ticksPerIntervalTurn);
@@ -90,7 +90,7 @@ void Chassis::driveFor(float forwardDistance, float forwardSpeed, bool block)
     leftMotor.moveFor(delta);
     rightMotor.moveFor(delta);
 
-    if(block) 
+    if(block)
     {
         while(!checkMotionComplete()) {delay(1);}
     }
@@ -109,7 +109,7 @@ void Chassis::turnFor(float turnAngle, float turningSpeed, bool block)
     leftMotor.moveFor(-delta);
     rightMotor.moveFor(delta);
 
-    if(block) 
+    if(block)
     {
         while(!checkMotionComplete()) {delay(1);}
     }
@@ -122,9 +122,9 @@ bool Chassis::checkMotionComplete(void)
 }
 
 /**
- * ISR for timing. On overflow of Timer4, the ISR takes a 'snapshot' of the encoder counts 
+ * ISR for timing. On overflow of Timer4, the ISR takes a 'snapshot' of the encoder counts
  * and then raises a flag to let the main program know it is time to execute the PID calculations.
- * 
+ *
  * Do not edit this function -- adding lengthy function calls will cause headaches.
  * */
 ISR(TIMER4_OVF_vect)

--- a/src/Chassis.cpp
+++ b/src/Chassis.cpp
@@ -156,3 +156,9 @@ void Chassis::printEncoderCounts(void)
     Serial.print(rightMotor.getCount());
     Serial.print('\n');
 }
+
+void Chassis::setEStop(bool eStop) {
+    // Set the EStops of the motors
+    leftMotor.setEStop(eStop);
+    rightMotor.setEStop(eStop);
+}

--- a/src/Chassis.h
+++ b/src/Chassis.h
@@ -6,14 +6,16 @@
 /** \class Chassis
  * The Chassis class manages the motors and encoders.
  *
- * Chassis sets up a hardware-based timer on a 16ms interval. At each interrupt, it
- * reads the current encoder counts and, if controlling for speed, calculates the
- * effort using a PID controller for each motor, which can be adjusted by the user.
+ * Chassis sets up a hardware-based timer on a 16ms interval. At each interrupt,
+ * it reads the current encoder counts and, if controlling for speed, calculates
+ * the effort using a PID controller for each motor, which can be adjusted by
+ * the user.
  *
- * The encoders are attached automatically and the encoders will count regardless of
- * the state of the robot.
+ * The encoders are attached automatically and the encoders will count
+ * regardless of the state of the robot.
  *
- * Several methods are provided for low level control to commands for driving or turning.
+ * Several methods are provided for low level control to commands for driving or
+ * turning.
  * */
 class Chassis
 {
@@ -33,9 +35,10 @@ public:
      * @param ticksPerRevolution Enccoder ticks per _wheel_ revolution.
      * @param wheelTrack Distance between wheels in cm.
      * */
-    Chassis(float wheelDiam = 7, float ticksPerRevolution = 1440, float wheelTrack = 14.7)
-        : cmPerEncoderTick(wheelDiam * M_PI / ticksPerRevolution), robotRadius(wheelTrack / 2.0)
-        {}
+    Chassis(float wheelDiam = 7, float ticksPerRevolution = 1440,
+            float wheelTrack = 14.7)
+        : cmPerEncoderTick(wheelDiam * M_PI / ticksPerRevolution),
+          robotRadius(wheelTrack / 2.0) {}
 
     /** \brief Initializes the chassis. Must be called in setup().
      * */
@@ -62,6 +65,20 @@ public:
      * @param rightSpeed Target speed for right wheel in cm/sec
      * */
     void setWheelSpeeds(float leftSpeed, float rightSpeed);
+
+    /**
+     * @brief Gets the current left wheel speed in cm/sec.
+     *
+     * @return float Current speed of the left wheel in cm/sec
+     */
+    float getLeftWheelSpeed(void);
+
+    /**
+     * @brief Gets the current right wheel speed in cm/sec.
+     *
+     * @return float Current speed of the right wheel in cm/sec
+     */
+    float getRightWheelSpeed(void);
 
     /** \brief Sets target motion for the chassis.
      *
@@ -104,14 +121,18 @@ public:
      * @param reset Resets the encoder count if true.
      * */
     int16_t getLeftEncoderCount(bool reset = false)
-        {return reset ? leftMotor.getAndResetCount() : leftMotor.getCount();}
+    {
+        return reset ? leftMotor.getAndResetCount() : leftMotor.getCount();
+    }
 
     /** \brief Returns the right encoder count.
      *
      * @param reset Resets the encoder count if true.
      * */
     int16_t getRightEncoderCount(bool reset = false)
-        {return reset ? rightMotor.getAndResetCount() : rightMotor.getCount();}
+    {
+        return reset ? rightMotor.getAndResetCount() : rightMotor.getCount();
+    }
 
     /** \brief Sets the eStop state of the robot
      *

--- a/src/Chassis.h
+++ b/src/Chassis.h
@@ -112,6 +112,12 @@ public:
      * */
     int16_t getRightEncoderCount(bool reset = false)
         {return reset ? rightMotor.getAndResetCount() : rightMotor.getCount();}
+
+    /** \brief Sets the eStop state of the robot
+     *
+     * @param eStop The desired eStop state
+     */
+    void setEStop(bool eStop);
 };
 
 extern Chassis chassis;

--- a/src/Chassis.h
+++ b/src/Chassis.h
@@ -5,15 +5,15 @@
 
 /** \class Chassis
  * The Chassis class manages the motors and encoders.
- * 
+ *
  * Chassis sets up a hardware-based timer on a 16ms interval. At each interrupt, it
- * reads the current encoder counts and, if controlling for speed, calculates the 
+ * reads the current encoder counts and, if controlling for speed, calculates the
  * effort using a PID controller for each motor, which can be adjusted by the user.
- * 
- * The encoders are attached automatically and the encoders will count regardless of 
+ *
+ * The encoders are attached automatically and the encoders will count regardless of
  * the state of the robot.
- * 
- * Several methods are provided for low level control to commands for driving or turning. 
+ *
+ * Several methods are provided for low level control to commands for driving or turning.
  * */
 class Chassis
 {
@@ -28,19 +28,19 @@ protected:
 
 public:
     /** \brief Chassis constructor.
-     * 
+     *
      * @param wheelDiam Wheel diameter in cm.
      * @param ticksPerRevolution Enccoder ticks per _wheel_ revolution.
      * @param wheelTrack Distance between wheels in cm.
      * */
-    Chassis(float wheelDiam = 7, float ticksPerRevolution = 1440, float wheelTrack = 14.7) 
+    Chassis(float wheelDiam = 7, float ticksPerRevolution = 1440, float wheelTrack = 14.7)
         : cmPerEncoderTick(wheelDiam * M_PI / ticksPerRevolution), robotRadius(wheelTrack / 2.0)
         {}
-    
+
     /** \brief Initializes the chassis. Must be called in setup().
      * */
     void init(void);
-    
+
     /** \brief Sets PID coefficients for the motors. Not independent.
      * */
     void setMotorPIDcoeffs(float kp, float ki);
@@ -50,38 +50,38 @@ public:
     void idle(void);
 
     /** \brief Sets motor efforts. Max speed is 420.
-     * 
+     *
      * @param leftEffort Effort for left motor
      * @param rightEffort Effort for right motor
      * */
     void setMotorEfforts(int leftEffort, int rightEffort);
 
     /** \brief Sets target wheel speeds in cm/sec.
-     * 
+     *
      * @param leftSpeed Target speed for left wheel in cm/sec
      * @param rightSpeed Target speed for right wheel in cm/sec
      * */
     void setWheelSpeeds(float leftSpeed, float rightSpeed);
 
     /** \brief Sets target motion for the chassis.
-     * 
+     *
      * @param forwardSpeed Target forward speed in cm/sec
      * @param rightSpeed Target spin rate in deg/sec
      * */
     void setTwist(float forwardSpeed, float turningSpeed);
 
     /** \brief Commands the robot to drive at a distance and speed.
-     * 
+     *
      * The chassis will stop when the distance is reached.
-     * 
+     *
      * @param forwardDistance Target distance in cm
      * @param forwardSpeed Target speed rate in cm/sec
      * @param block If true, the function blocks until the motion is complete
      * */
     void driveFor(float forwardDistance, float forwardSpeed, bool block = false);
-    
+
     /** \brief Commands the chassis to turn a set angle.
-     * 
+     *
      * @param turnAngle Target angle to turn in degrees
      * @param turningSpeed Target spin rate in deg/sec
      * @param block If true, the function blocks until the motion is complete
@@ -89,7 +89,7 @@ public:
     void turnFor(float turnAngle, float turningSpeed, bool block = false);
 
     /** \brief Checks if the motion commanded by driveFor() or turnFor() is done.
-     * 
+     *
      * \return Returns true if the motion is complete.
      * */
     bool checkMotionComplete(void);
@@ -100,17 +100,17 @@ public:
     inline void updateEncoderDeltas();
 
     /** \brief Returns the left encoder count.
-     * 
+     *
      * @param reset Resets the encoder count if true.
      * */
-    int16_t getLeftEncoderCount(bool reset = false) 
+    int16_t getLeftEncoderCount(bool reset = false)
         {return reset ? leftMotor.getAndResetCount() : leftMotor.getCount();}
 
     /** \brief Returns the right encoder count.
-     * 
+     *
      * @param reset Resets the encoder count if true.
      * */
-    int16_t getRightEncoderCount(bool reset = false) 
+    int16_t getRightEncoderCount(bool reset = false)
         {return reset ? rightMotor.getAndResetCount() : rightMotor.getCount();}
 };
 

--- a/src/IRdecoder.cpp
+++ b/src/IRdecoder.cpp
@@ -36,7 +36,7 @@ void IRDecoder::handleIRsensor(void)
   //if(!FastGPIO::Pin<14>::isInputHigh()) // could use FastGPIO for speed
   if(!digitalRead(pin)) // FALLING edge
   {
-    fallingEdge = currUS; 
+    fallingEdge = currUS;
   }
 
   else // RISING edge
@@ -49,14 +49,14 @@ void IRDecoder::handleIRsensor(void)
     lastRisingEdge = risingEdge;
 
     // bits[index] = delta; //used for debugging; obsolete
-    
+
     if(delta > 8500 && delta < 9500) // received a start pulse
     {
       index = 0;
       state = IR_PREAMBLE;
       return;
     }
-    
+
     //a pulse is supposed to be 562.5 us, but I found that it averaged 620us or so
     //with the sensor that we're using, which is NOT optimized for IR remotes --
     //it's actually optimized for sensitivity. So I set the maximum accepted pulse
@@ -81,7 +81,7 @@ void IRDecoder::handleIRsensor(void)
       else if(codeLength < 3300 && codeLength > 2700) //repeat code
       {
         state = IR_REPEAT;
-        if(((currCode ^ (currCode >> 8)) & 0x00ff0000) != 0x00ff0000) {state = IR_ERROR;} 
+        if(((currCode ^ (currCode >> 8)) & 0x00ff0000) != 0x00ff0000) {state = IR_ERROR;}
         lastReceiveTime = millis(); //not really used
       }
     }
@@ -92,13 +92,13 @@ void IRDecoder::handleIRsensor(void)
       {
         index++;
       }
-      
+
       else if(codeLength < 2500 && codeLength > 2000) //long = 1
       {
         currCode += ((uint32_t)1 << index);
         index++;
       }
-      
+
       else //error
       {
         state = IR_ERROR;
@@ -110,7 +110,7 @@ void IRDecoder::handleIRsensor(void)
         if(((currCode ^ (currCode >> 8)) & 0x00ff0000) != 0x00ff0000) state = IR_ERROR;
 
         else //we're good to go
-        {        
+        {
           state = IR_COMPLETE;
           lastReceiveTime = millis();
         }

--- a/src/IRdecoder.h
+++ b/src/IRdecoder.h
@@ -1,20 +1,20 @@
-#pragma once 
+#pragma once
 
 #include <Arduino.h>
 
 /** \class IRDecoder
- * A class to interpret IR remotes with NEC encoding. 
- * 
+ * A class to interpret IR remotes with NEC encoding.
+ *
  * NEC encoding sends four bytes: [device ID, ~divice ID, key code, ~key code]
- * 
+ *
  * Sending the inverse allow for easy error checking (and reduces saturation in the receiver).
- * 
+ *
  * Codes are send in little endian; this library reverses upon reception, so the first bit received
  * is in the LSB of currCode. That means that the key code is found in bits [23..16] of currCode
- * 
+ *
  * https://techdocs.altium.com/display/FPGA/NEC+Infrared+Transmission+Protocol
- * 
- * This does not interpret the codes into which key was pressed. That needs to be 
+ *
+ * This does not interpret the codes into which key was pressed. That needs to be
  * mapped on a remote by remote basis.
  */
 class IRDecoder
@@ -30,7 +30,7 @@ private:
     IR_ACTIVE,   //have some bits, but not yet complete
     IR_COMPLETE, //a valid code has been received
     IR_ERROR     //an error occurred; won't return a valid code
-  }; 
+  };
 
   IR_STATE state = IR_READY; //a simple state machine for managing reception
 

--- a/src/LSM6.cpp
+++ b/src/LSM6.cpp
@@ -81,7 +81,7 @@ void LSM6::setFullScaleAcc(ACC_FS afs)
     mg = 0.061;
     break;
   case ACC_FS4:
-    writeReg(LSM6::CTRL1_XL, 0b00001000); 
+    writeReg(LSM6::CTRL1_XL, 0b00001000);
     mg = 0.122;
     break;
   case ACC_FS8:
@@ -99,7 +99,7 @@ void LSM6::setFullScaleAcc(ACC_FS afs)
 
 void LSM6::setGyroDataOutputRate(ODR rate)
 {
-  if(rate < 0 || rate > ODR166k) 
+  if(rate < 0 || rate > ODR166k)
   {
     Serial.println(F("Illegal gyro ODR"));
     return;
@@ -111,7 +111,7 @@ void LSM6::setGyroDataOutputRate(ODR rate)
 
 void LSM6::setAccDataOutputRate(ODR rate)
 {
-  if(rate < 0 || rate > ODR166k) 
+  if(rate < 0 || rate > ODR166k)
   {
     Serial.println(F("Illegal acc ODR"));
     return;

--- a/src/LSM6.h
+++ b/src/LSM6.h
@@ -19,14 +19,14 @@ class LSM6
 
     enum ACC_FS {ACC_FS2, ACC_FS4, ACC_FS8, ACC_FS16};
     enum GYRO_FS {GYRO_FS245, GYRO_FS500, GYRO_FS1000, GYRO_FS2000};
-    enum ODR 
+    enum ODR
     {
-      ODR13 = 0x1, 
-      ODR26 = 0x2, 
-      ODR52 = 0x3, 
-      ODR104 = 0x4, 
-      ODR208 = 0x5, 
-      ODR416 = 0x6, 
+      ODR13 = 0x1,
+      ODR26 = 0x2,
+      ODR52 = 0x3,
+      ODR104 = 0x4,
+      ODR208 = 0x5,
+      ODR416 = 0x6,
       ODR833 = 0x7,
       ODR166k = 0x8
     };

--- a/src/PIDcontroller.cpp
+++ b/src/PIDcontroller.cpp
@@ -2,7 +2,7 @@
 #include <math.h>
 
 /** \brief Used to calculate the effort from the error.
- * 
+ *
  * \param error The current error (which is calculated in the calling code).
  * */
 float PIDController::calcEffort(float error)
@@ -12,7 +12,7 @@ float PIDController::calcEffort(float error)
 
     if(errorBound > 0) //cap error; errorBound == 0 means don't cap
     {
-        if(fabs(sumError) > errorBound) 
+        if(fabs(sumError) > errorBound)
         {
             sumError -= currError; //if we exceeded the limit, just subtract it off again
         }

--- a/src/PIDcontroller.h
+++ b/src/PIDcontroller.h
@@ -3,7 +3,7 @@
 #include <Arduino.h>
 
 /** \brief A generic PID controller.
- * 
+ *
  * If errorBound is non-zero, the integral will be capped at that value.
  * */
 class PIDController
@@ -12,7 +12,7 @@ protected:
     float Kp, Ki, Kd;
     float currError = 0;
     float prevError = 0;
-    
+
     float sumError = 0;
     float errorBound = 0;
 
@@ -22,11 +22,11 @@ protected:
 
 public:
     /** \brief Constructor defaults to proportional only. */
-    PIDController(float p, float i = 0, float d = 0, float bound = 0) 
+    PIDController(float p, float i = 0, float d = 0, float bound = 0)
         : Kp(p), Ki(i), Kd(d), errorBound(bound) {}
-    
+
     float calcEffort(float error);
-    
+
     float setKp(float k) {return Kp = k;}
     float setKi(float k) {sumError = 0; return Ki = k;}
     float setKd(float k) {return Kd = k;}

--- a/src/Rangefinder.cpp
+++ b/src/Rangefinder.cpp
@@ -4,11 +4,11 @@
 #define ECHO_RECD   0x02
 
 /** \brief Constructor.
- * 
+ *
  * @param echo The echo pin. Must be interrupt enabled. PCInts OK.
  * @param trig The trigger pin.
  * */
-Rangefinder::Rangefinder(uint8_t echo, uint8_t trig) 
+Rangefinder::Rangefinder(uint8_t echo, uint8_t trig)
 {
     echoPin = echo;
     trigPin = trig;
@@ -42,10 +42,10 @@ void Rangefinder::init(void)
 
 /**
  * \brief checkPingTimer() checks to see if it's time to send a new ping.
- * 
+ *
  * You can make the pingInterval arbitrarily small, since it won't send a ping
  * if the ECHO pin is HIGH.
- * 
+ *
  * getDistance() calls this function, so you don't need to call this function manually.
  */
 uint8_t Rangefinder::checkPingTimer(void)
@@ -54,9 +54,9 @@ uint8_t Rangefinder::checkPingTimer(void)
      * if the echo pin is still high, just update the last ping time
      * which will delay the next ping so we don't reset the ping
      * while one is in the air
-     * 
+     *
      * 'lastPing' is a slight misnomer; it's really the last time we checked
-    */ 
+    */
     if(digitalRead(echoPin)) lastPing = millis();
 
     // check if we're ready to ping
@@ -71,7 +71,7 @@ uint8_t Rangefinder::checkPingTimer(void)
         sei();
 
         // keep track of when we sent the last ping
-        lastPing = millis();  
+        lastPing = millis();
 
         // toggle the trigger pin to send a chirp
         digitalWrite(trigPin, HIGH); //commands a ping; leave high for the duration
@@ -108,7 +108,7 @@ float Rangefinder::getDistance(void)
 }
 
 /** \brief ISR for the echo pin
- * 
+ *
  * Records both the start and stop (rise and fall) of the echo pin.
  * When the pin goes low, it sets a flag.
  * */
@@ -123,7 +123,7 @@ void Rangefinder::ISR_echo(void)
     {
         pulseEnd = micros();
         state |= ECHO_RECD;
-    } 
+    }
 }
 
 /** A global ISR, which calls Rangefinder::ISR_echo()

--- a/src/Rangefinder.h
+++ b/src/Rangefinder.h
@@ -2,17 +2,17 @@
 
 #include <Arduino.h>
 
-/** \class Rangefinder 
- * \brief A class to manage the HC-SR04 ultrasonic rangefinder. 
- * 
+/** \class Rangefinder
+ * \brief A class to manage the HC-SR04 ultrasonic rangefinder.
+ *
  * Uses a TRIG and ECHO pin to send chirps and detect round trip time.
- * 
- * The object rangefinder is declared extern to work with the ISRs, which 
+ *
+ * The object rangefinder is declared extern to work with the ISRs, which
  * means you must define your object with the same name:
- * 
+ *
  * Rangefinder rangefinder(<echo>, <trigger>);
  * */
-class Rangefinder 
+class Rangefinder
 {
 protected:
     volatile uint8_t state = 0;
@@ -21,12 +21,12 @@ protected:
     uint8_t trigPin = -1;
 
     // for keeping track of ping intervals
-    uint32_t lastPing = 0;     
+    uint32_t lastPing = 0;
 
     // we set the pingInterval to 10 ms, but it won't actually ping that fast
     // since it _only_ pings if the ECHO pin is low -- that is, it will ping
-    // in 10 ms or when the last echo is done, whichever is _longer_ 
-    uint32_t pingInterval = 10;    
+    // in 10 ms or when the last echo is done, whichever is _longer_
+    uint32_t pingInterval = 10;
 
     // for keeping track of echo duration
     volatile uint32_t pulseStart = 0;
@@ -47,7 +47,7 @@ public:
     // checks to see if an echo is complete
     uint16_t checkEcho(void);
 
-    /** \brief Returns the last recorded distance in cm. The first call to 
+    /** \brief Returns the last recorded distance in cm. The first call to
      * getDistance() will return 99.
      * */
     float getDistance(void);

--- a/src/Romi32U4Encoders.cpp
+++ b/src/Romi32U4Encoders.cpp
@@ -20,11 +20,11 @@ void rightISR(void);
 
 /**
  * Set up the encoder 'machinery'. Call it near the beginning of the program.
- * 
+ *
  * Do not edit this function.
  * */
 void Romi32U4Motor::initEncoders(void)
-{    
+{
     Serial.println("initEncoders()");
     // Set the pins as pulled-up inputs.
     FastGPIO::Pin<LEFT_XOR>::setInputPulledUp();
@@ -83,12 +83,12 @@ int16_t Romi32U4Motor::getAndResetCount(void)
 }
 
 /**
- * calcEncoderDelta() is called automatically by an ISR. It takes a 'snapshot of the encoders and 
- * stores the change since the last call in speed, which has units of "encoder ticks/16 ms interval" 
- * 
+ * calcEncoderDelta() is called automatically by an ISR. It takes a 'snapshot of the encoders and
+ * stores the change since the last call in speed, which has units of "encoder ticks/16 ms interval"
+ *
  * Because it is called from within an ISR, interrupts don't need to be disabled.
  * */
-void Romi32U4Motor::calcEncoderDelta(void) 
+void Romi32U4Motor::calcEncoderDelta(void)
 {
     int16_t currCount = count;
     speed = currCount - prevCount;
@@ -98,12 +98,12 @@ void Romi32U4Motor::calcEncoderDelta(void)
 /**
  * Calculates the encoder counter increment/decrement due to an encoder transition. Pololu sets
  * up their encoders in an interesting way with some logic chips, so first we have to deconvolute
- * the encoder signals (in the ISR); then, we call this function to  update the counter. 
- * 
+ * the encoder signals (in the ISR); then, we call this function to  update the counter.
+ *
  * More details are found here:
- * 
+ *
  * https://www.pololu.com/docs/0J69/3.3
- * 
+ *
  * This function is called from the ISR, which does the actual deconvolution for each motor.
  * */
 void Romi32U4Motor::handleISR(bool newA, bool newB)

--- a/src/Romi32U4Motors.cpp
+++ b/src/Romi32U4Motors.cpp
@@ -61,6 +61,7 @@ void Romi32U4Motor::initMotors()
  * */
 void LeftMotor::setEffort(int16_t effort)
 {
+    if (eStop) return;
     bool reverse = 0;
 
     if (effort < 0)
@@ -79,6 +80,7 @@ void LeftMotor::setEffort(int16_t effort)
 
 void RightMotor::setEffort(int16_t effort)
 {
+    if (eStop) return;
     bool reverse = 0;
 
     if (effort < 0)

--- a/src/Romi32U4Motors.cpp
+++ b/src/Romi32U4Motors.cpp
@@ -17,7 +17,7 @@
  * It sets up Timer4 to run at 38 kHz, which is used to both drive the PWM signal for the motors
  * and (tangentially) allow for a 38 kHz signal on pin 11, which can be used, say, to drive an
  * IR LED at a common rate.
- * 
+ *
  * Timer 1 has the following configuration:
  *  prescaler of 1
  *  outputs enabled on channels A (pin 9), B (pin 10) and C (pin 11)
@@ -46,7 +46,7 @@ void Romi32U4Motor::initMotors()
     OCR1A = 0;
     OCR1B = 0;
     OCR1C = 0; //can be used to create 38 kHz signal on pin 11
-    
+
     interrupts(); //re-enable interrupts
 
     Serial.println("/initMotors()");
@@ -55,7 +55,7 @@ void Romi32U4Motor::initMotors()
 /**
  * Because the Pololu library is based on the FastGPIO library, we don't/can't use analogWrite.
  * Instead, we set the duty cycle directly at the register level.
- * 
+ *
  * We also have to have separate classes for the left and right motors to avoid the complex
  * mapping of speeds to registers.
  * */
@@ -106,7 +106,7 @@ void Romi32U4Motor::allowTurbo(bool turbo)
 /**
  * update() must be called regularly to update the control signals sent to the motors.
  * */
-void Romi32U4Motor::update(void) 
+void Romi32U4Motor::update(void)
 {
     if(ctrlMode == CTRL_SPEED || ctrlMode == CTRL_POS)
     {

--- a/src/Romi32U4Motors.h
+++ b/src/Romi32U4Motors.h
@@ -6,14 +6,14 @@
 
 #include <Arduino.h>
 #include <stdint.h>
-#include <PIDController.h>
+#include <PIDcontroller.h>
 
 /** \class Romi32U4Motor
  * Controls motor effort and direction on the Romi 32U4.
  *
  * This library uses Timer 1, so it will conflict with any other libraries using
- * that timer. 
- * 
+ * that timer.
+ *
  * Also reads counts from the encoders on the Romi 32U4.
  *
  * This class allows you to read counts from the encoders on the Romi 32U4,
@@ -69,7 +69,7 @@ public:
    }
 
 protected:
-   // Used to set up motors and encoders. Do not call directly; they are called from init(), which 
+   // Used to set up motors and encoders. Do not call directly; they are called from init(), which
    // is called from Chassis::init()
    static void initMotors();
    static void initEncoders();
@@ -116,7 +116,7 @@ public:
      *   If false, turns turbo mode off. */
    void allowTurbo(bool turbo);
 
-   /** 
+   /**
     * Service function for the ISR
     * */
    inline void handleISR(bool newA, bool newB);
@@ -124,7 +124,7 @@ public:
 
 /**
  * \class LeftMotor
- * 
+ *
  * A derived class for the left motor.
  * */
 class LeftMotor : public Romi32U4Motor
@@ -132,7 +132,7 @@ class LeftMotor : public Romi32U4Motor
 protected:
    void setEffort(int16_t effort);
 
-public: 
+public:
    /** Used to set the motor effort directly. It will properly control the mode. */
    void setMotorEffort(int16_t effort)
    {
@@ -143,7 +143,7 @@ public:
 
 /**
  * \class RightMotor
- * 
+ *
  * A derived class for the right motor.
  * */
 class RightMotor : public Romi32U4Motor

--- a/src/pcint.cpp
+++ b/src/pcint.cpp
@@ -1,10 +1,10 @@
 #include <pcint.h>
 
 //define an ISR function pointer; ISRs are of type void fxn(void)
-typedef void(*PCISR)(void); 
+typedef void(*PCISR)(void);
 
 //array to hold all of the indivicual ISRs; initialize to null
-PCISR pcISR[] = {0, 0, 0, 0, 0, 0, 0, 0}; 
+PCISR pcISR[] = {0, 0, 0, 0, 0, 0, 0, 0};
 
 //store the previous state -- needed to find which have changed
 static volatile uint8_t lastB = PINB; //these are likely all 0 at the start
@@ -31,13 +31,13 @@ ISR(PCINT0_vect)
     volatile uint8_t pinsB = PINB;
 
     //find the pins that have changed
-    volatile uint8_t deltaB = pinsB ^ lastB;                
+    volatile uint8_t deltaB = pinsB ^ lastB;
 
     //we're only interested in pins that have changed AND are set for interrupts
-    volatile uint8_t maskedDeltaB = deltaB & PCMSK0;        
-    
+    volatile uint8_t maskedDeltaB = deltaB & PCMSK0;
+
     //each of these checks if each ISR should run
-    if((maskedDeltaB & (1 << PCINT0))) {pcISR[PCINT0]();}   
+    if((maskedDeltaB & (1 << PCINT0))) {pcISR[PCINT0]();}
     if((maskedDeltaB & (1 << PCINT1))) {pcISR[PCINT1]();}
     if((maskedDeltaB & (1 << PCINT2))) {pcISR[PCINT2]();}
     if((maskedDeltaB & (1 << PCINT3))) {pcISR[PCINT3]();}
@@ -47,7 +47,7 @@ ISR(PCINT0_vect)
     if((maskedDeltaB & (1 << PCINT7))) {pcISR[PCINT7]();}
 
     //update last pin states
-    lastB = pinsB;                                          
+    lastB = pinsB;
 }
 
 uint8_t digitalPinToPCInterrupt(uint8_t pin)

--- a/src/servo32u4.cpp
+++ b/src/servo32u4.cpp
@@ -11,7 +11,7 @@ uint16_t Servo32U4Base::setMinMaxMicroseconds(uint16_t min, uint16_t max)
     return usMax - usMin; //return the range, in case the user wants to do a sanity check
 }
 
-void Servo32U4Pin5::attach(void) 
+void Servo32U4Pin5::attach(void)
 {
     pinMode(5, OUTPUT); // set pin as OUTPUT
 
@@ -52,7 +52,7 @@ void Servo32U4Pin5::writeMicroseconds(uint16_t microseconds)
     OCR3A = (microseconds << 1) - 1; // multiplies by 2
 }
 
-void Servo32U4Pin6::attach(void) 
+void Servo32U4Pin6::attach(void)
 {
     pinMode(6, OUTPUT); // set pin as OUTPUT
 
@@ -66,7 +66,7 @@ void Servo32U4Pin6::attach(void)
     isAttached = true;
 }
 
-void Servo32U4Pin6::detach(void) 
+void Servo32U4Pin6::detach(void)
 {
     cli();
 
@@ -92,7 +92,7 @@ void Servo32U4Pin6::writeMicroseconds(uint16_t microseconds)
     OCR4D = (microseconds >> 6) - 1; // divides by 64
 }
 
-void Servo32U4Pin13::attach(void) 
+void Servo32U4Pin13::attach(void)
 {
     pinMode(13, OUTPUT); // set pin as OUTPUT
 
@@ -106,7 +106,7 @@ void Servo32U4Pin13::attach(void)
     isAttached = true;
 }
 
-void Servo32U4Pin13::detach(void) 
+void Servo32U4Pin13::detach(void)
 {
     cli();
 
@@ -132,7 +132,7 @@ void Servo32U4Pin13::writeMicroseconds(uint16_t microseconds)
     OCR4A = (microseconds >> 6) - 1; // divides by 64
 }
 
-void Servo32U4Pin12::attach(void) 
+void Servo32U4Pin12::attach(void)
 {
     pinMode(12, OUTPUT); // set pin as OUTPUT
 
@@ -146,7 +146,7 @@ void Servo32U4Pin12::attach(void)
     isAttached = true;
 }
 
-void Servo32U4Pin12::detach(void) 
+void Servo32U4Pin12::detach(void)
 {
     cli();
 

--- a/src/servo32u4.h
+++ b/src/servo32u4.h
@@ -2,26 +2,26 @@
 
 #include <Arduino.h>
 
-/** \file Manages servos on up to three pins: 
- *  pin 5, 
+/** \file Manages servos on up to three pins:
+ *  pin 5,
  *  pin 13, and
  *  either pin 6 OR 12 (don't use 6 and 12 simultaneously!).
- * 
+ *
  * Pin 5 uses Timer3 and has the fewest restrictions as well as the highest precision (0.5 us).
- * 
+ *
  * The other three have potential conflicts and much lower resolution (64 us).
- * 
+ *
  * Pin 13 uses Timer4, but shares functionality with the bootloader, which flashes the LED connected
  * to that pin. So, your servo will go a bit nuts when you upload -- be careful!
- * 
- * Pins 6 and 12 use Timer4, but share the same output compare -- except that they are inverted! 
+ *
+ * Pins 6 and 12 use Timer4, but share the same output compare -- except that they are inverted!
  * Practically, that means you can use one or the other. Note that pin 6 is shared with the buzzer,
  * so you'll need to cut the buzzer trace if you want to use that pin and maintain your sanity.
- * 
+ *
  * We define a legacy "Servo32U4", which is on pin 5 -- this matches the original functionality of this
- * library, though it will likely be dropped in future versions. You just need to change all instances 
+ * library, though it will likely be dropped in future versions. You just need to change all instances
  * of Servo32U4 to Servo32U4Pin5.
- * 
+ *
  * */
 
 // Define the 'legacy' Servo32U4 as Servo32U4Pin5
@@ -29,11 +29,11 @@
 
 /** \class Servo32U4Base
  * \brief Base class class for servos.
- * 
+ *
  * Each derived class controls a specific pin (obvious from the name).
- * 
+ *
  * Legacy Servo32U4 is #defined for pin 5, which is how it was used previously.
- * 
+ *
  * Defaults to a range of 1000 - 2000 us, but can be customized.
  */
 class Servo32U4Base
@@ -56,12 +56,12 @@ public:
 
 /** \class Servo32U4Pin5
  * \brief A servo class to control a servo on pin 5.
- * 
- * Servo32U4 uses output compare on Timer3 to control the pulse to the servo. 
+ *
+ * Servo32U4 uses output compare on Timer3 to control the pulse to the servo.
  * The 16-bit Timer3 is set up with a pre-scaler of 8, TOP of 39999 + 1 => 20 ms interval.
- * 
- * OCR3A controls the pulse on pin 5 -- this servo must be on pin 5! 
- * 
+ *
+ * OCR3A controls the pulse on pin 5 -- this servo must be on pin 5!
+ *
  * Defaults to a range of 1000 - 2000 us, but can be customized.
  */
 class Servo32U4Pin5 :public Servo32U4Base
@@ -74,21 +74,21 @@ public:
 
 /** \class Servo32U4Pin6
  * \brief A servo class to control a servo on pin 6.
- * 
- * Servo32U4Pin6 uses output compare on Timer4 to control the pulse to the servo. 
+ *
+ * Servo32U4Pin6 uses output compare on Timer4 to control the pulse to the servo.
  * _In Chassis::init(),
  * The 8-bit Timer4 is set up with a pre-scaler of 1024, TOP of 249 + 1 => 16 ms interval.
- * 
- * YOU MUST CALL Chasssis::init() IN setup() FOR THIS TO WORK, 
+ *
+ * YOU MUST CALL Chasssis::init() IN setup() FOR THIS TO WORK,
  * AND YOU MUST CALL Chassis::init() BEFORE YOU CALL attach()
- * 
- * OCR4D controls the pulse on pin 6 -- this servo must be on pin 6! 
- * 
- * Note that pin 6 controls the buzzer, so you'll go crazy if you don't cut the buzzer trace. 
+ *
+ * OCR4D controls the pulse on pin 6 -- this servo must be on pin 6!
+ *
+ * Note that pin 6 controls the buzzer, so you'll go crazy if you don't cut the buzzer trace.
  * See: https://www.pololu.com/docs/0J69/3.2 for how to cut the trace.
- * 
+ *
  * Defaults to a range of 1000 - 2000 us, but can be customized.
- * 
+ *
  * Note that because we're using an 8-bit timer, resolution is only 64 us.
  */
 class Servo32U4Pin6 : public Servo32U4Base
@@ -101,22 +101,22 @@ public:
 
 /** \class Servo32U4Pin13
  * \brief A servo class to control a servo on pin 13.
- * 
- * Servo32U4Pin6 uses output compare on Timer4 to control the pulse to the servo. 
+ *
+ * Servo32U4Pin6 uses output compare on Timer4 to control the pulse to the servo.
  * _In Chassis::init(),
  * The 8-bit Timer4 is set up with a pre-scaler of 1024, TOP of 249 + 1 => 16 ms interval.
- * 
- * YOU MUST CALL Chasssis::init() IN setup() FOR THIS TO WORK, 
+ *
+ * YOU MUST CALL Chasssis::init() IN setup() FOR THIS TO WORK,
  * AND YOU MUST CALL Chassis::init() BEFORE YOU CALL attach()
- * 
- * OCR4A controls the pulse on pin 13 -- this servo must be on pin 13! 
- * 
+ *
+ * OCR4A controls the pulse on pin 13 -- this servo must be on pin 13!
+ *
  * Note that there is a useful LED on pin 13 -- you'll lose that functionality.
- * 
+ *
  * Pin 13 is also used during the upload process, so your servo will go crazy when uploading!
- * 
+ *
  * Defaults to a range of 1000 - 2000 us, but can be customized.
- * 
+ *
  * Note that because we're using an 8-bit timer, resolution is only 64 us.
  */
 class Servo32U4Pin13 : public Servo32U4Base
@@ -129,20 +129,20 @@ public:
 
 /** \class Servo32U4Pin12
  * \brief A servo class to control a servo on pin 12.
- * 
- * Servo32U4Pin12 uses output compare on Timer4 to control the pulse to the servo. 
+ *
+ * Servo32U4Pin12 uses output compare on Timer4 to control the pulse to the servo.
  * _In Chassis::init(),
  * The 8-bit Timer4 is set up with a pre-scaler of 1024, TOP of 249 + 1 => 16 ms interval.
- * 
- * YOU MUST CALL Chasssis::init() IN setup() FOR THIS TO WORK, 
+ *
+ * YOU MUST CALL Chasssis::init() IN setup() FOR THIS TO WORK,
  * AND YOU MUST CALL Chassis::init() BEFORE YOU CALL attach()
- * 
+ *
  * ^OCR4D controls the pulse on pin 12 -- this servo _must_ be on pin 12!
- * 
+ *
  * DO NOT USE IN CONJUNCTION WITH Servo32U4Pin12
- * 
+ *
  * Defaults to a range of 1000 - 2000 us, but can be customized.
- * 
+ *
  * Note that because we're using an 8-bit timer, resolution is only 64 us.
  */
 class Servo32U4Pin12 : public Servo32U4Base


### PR DESCRIPTION
PID controller class is "PIDController", but file is named "PIDcontroller.h". There was a reference in the src/Romi32U4Motors.h that attempted to include the header using "PIDController.h". This caused build errors, so I changed the include statement. I would have preferred to change the names of the cpp and header files to be PascalCase, but that could cause issues with backwards compatibility. 

I also removed trailing whitespace in all of the files.